### PR TITLE
ESTS-131427: adding test for node-discovery rmq port check

### DIFF
--- a/test-packs/test_suites/continuous-integration-deploy-suite/node-expansion-ci-cd/test_a_dne_a_services_checks.py
+++ b/test-packs/test_suites/continuous-integration-deploy-suite/node-expansion-ci-cd/test_a_dne_a_services_checks.py
@@ -56,9 +56,10 @@ def test_dne_services_up(service_name, setup):
     assert not err
 
 
-#"symphony-node-discovery-paqx", , "symphony-rackhd-adapter-service" This has been removed as there is a defect open for it
+#"symphony-rackhd-adapter-service" This has been removed as there is a defect open for it
 @pytest.mark.parametrize('service_name',["symphony-engineering-standards-service", "symphony-dne-paqx",
-                          "symphony-vcenter-adapter-service","cpsd-scaleio-adapter-service"])
+                          "symphony-vcenter-adapter-service","cpsd-scaleio-adapter-service",
+                                         "symphony-node-discovery-paqx"])
 @pytest.mark.daily_status
 @pytest.mark.dne_paqx_parent_mvp
 @pytest.mark.dne_paqx_parent_mvp_extended


### PR DESCRIPTION
hi Vishaka, this is just enabling the python test to check the rmq connections for node-discovery-paqx. It passes locally.