### PR TITLE
Ren-enabling two tests to test code change to reduce encryption to 2048bit

### DIFF
--- a/test-packs/test_suites/continuous-integration-deploy-suite/rcm-fitness-ci-cd/l_downloadFirmware/test_l_downloadFirmware-REST.py
+++ b/test-packs/test_suites/continuous-integration-deploy-suite/rcm-fitness-ci-cd/l_downloadFirmware/test_l_downloadFirmware-REST.py
@@ -498,11 +498,11 @@ def test_verifyRESTdownloadSingleFileRequestSTATUS1():
         "3.2", "3.2.1")
 
 
-# @pytest.mark.daily_status
-# @pytest.mark.rcm_fitness_mvp_extended
-# def test_verifyRESTrepositoryStatus1():
-#     verifyRESTrepositoryStatus("RCM/3.2.1/VxRack_1000_FLEX/Component/Controller_Firmware/",
-#                                "SAS-RAID_Firmware_VH28K_WN64_25.4.0.0017_A06.EXE")
+@pytest.mark.daily_status
+@pytest.mark.rcm_fitness_mvp_extended
+def test_verifyRESTrepositoryStatus1():
+    verifyRESTrepositoryStatus("RCM/3.2.1/VxRack_1000_FLEX/Component/Controller_Firmware/",
+                               "SAS-RAID_Firmware_VH28K_WN64_25.4.0.0017_A06.EXE")
 
 
 @pytest.mark.rcm_fitness_mvp_extended
@@ -519,10 +519,10 @@ def test_verifyRESTdownloadSingleFileRequestSTATUS2():
         "3.2", "3.2.3")
 
 
-# @pytest.mark.rcm_fitness_mvp_extended
-# def test_verifyRESTrepositoryStatus2():
-#     verifyRESTrepositoryStatus("RCM/3.2.3/VxRack_1000_FLEX/Component/Controller_Firmware/",
-#                                "SAS-RAID_Firmware_2H45F_WN64_25.5.0.0018_A08.EXE")
+@pytest.mark.rcm_fitness_mvp_extended
+def test_verifyRESTrepositoryStatus2():
+    verifyRESTrepositoryStatus("RCM/3.2.3/VxRack_1000_FLEX/Component/Controller_Firmware/",
+                               "SAS-RAID_Firmware_2H45F_WN64_25.5.0.0018_A08.EXE")
 
 
 @pytest.mark.rcm_fitness_mvp_extended


### PR DESCRIPTION
verifyRESTRepositoryStatus2, in order to test code change
to reduce to 2048 bit encryption